### PR TITLE
V0.9.29

### DIFF
--- a/README-devtools-MDH.mm
+++ b/README-devtools-MDH.mm
@@ -11,7 +11,7 @@
 <font SIZE="24"/>
 <stylenode LOCALIZED_TEXT="styles.predefined" POSITION="right" STYLE="bubble">
 <stylenode LOCALIZED_TEXT="default" ID="ID_271890427" ICON_SIZE="12 pt" FORMAT_AS_HYPERLINK="false" COLOR="#000000" STYLE="fork" NUMBERED="false" FORMAT="STANDARD_FORMAT" TEXT_ALIGN="DEFAULT" MAX_WIDTH="10 cm" MIN_WIDTH="0 cm" VGAP_QUANTITY="2 pt" BORDER_WIDTH_LIKE_EDGE="false" BORDER_WIDTH="1 px" BORDER_COLOR_LIKE_EDGE="true" BORDER_COLOR="#808080" BORDER_DASH_LIKE_EDGE="false" BORDER_DASH="SOLID">
-<arrowlink SHAPE="CUBIC_CURVE" COLOR="#000000" WIDTH="2" TRANSPARENCY="200" DASH="" FONT_SIZE="9" FONT_FAMILY="SansSerif" DESTINATION="ID_271890427" STARTINCLINATION="65.25 pt;-30.75 pt;" ENDINCLINATION="55.5 pt;18.75 pt;" STARTARROW="NONE" ENDARROW="DEFAULT"/>
+<arrowlink SHAPE="CUBIC_CURVE" COLOR="#000000" WIDTH="2" TRANSPARENCY="200" DASH="" FONT_SIZE="9" FONT_FAMILY="SansSerif" DESTINATION="ID_271890427" STARTINCLINATION="65.25 pt;-29.25 pt;" ENDINCLINATION="55.5 pt;18.75 pt;" STARTARROW="NONE" ENDARROW="DEFAULT"/>
 <font NAME="SansSerif" SIZE="10" BOLD="false" STRIKETHROUGH="false" ITALIC="false"/>
 <richcontent CONTENT-TYPE="plain/auto" TYPE="DETAILS"/>
 <richcontent TYPE="NOTE" CONTENT-TYPE="plain/auto"/>
@@ -390,8 +390,7 @@ blockquote {
       = edofro.MarkDownHelper.MDH.textBlock(node)
     </p>
   </body>
-</html>
-</richcontent>
+</html></richcontent>
 <node TEXT="download" ID="ID_1900518132"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
@@ -402,8 +401,7 @@ blockquote {
       The instalable file (```$1-$2.addon.mm```) of the latest version of the this fork can be downloaded from $3.
     </p>
   </body>
-</html>
-</richcontent>
+</html></richcontent>
 <node TEXT="devtools" ID="ID_954321371"/>
 <node TEXT="using formula in note of this node to get vX.X.X from list in &apos;change log&apos; node" ID="ID_1280078698" LINK="#ID_1015823873"><richcontent TYPE="NOTE" CONTENT-TYPE="plain/">
     <text>=node.link?.node?.children?.first()?.text?:&apos;vX.X.X&apos;</text>
@@ -419,8 +417,7 @@ blockquote {
       = edofro.MarkDownHelper.MDH.webLink(node)
     </p>
   </body>
-</html>
-</richcontent>
+</html></richcontent>
 <node TEXT="here" ID="ID_328387021" LINK="https://github.com/EdoFro/freeplane-devtools/releases/latest/"/>
 </node>
 </node>
@@ -568,11 +565,16 @@ blockquote {
   </body>
 </html></richcontent>
 <node TEXT="When building a new add-on, now it adds a new &quot;**action**&quot; node." ID="ID_44269758"/>
-<node TEXT="This node has two children nodes with links to the &quot;**Build add-on**&quot; and &quot;**Package add-on for publication**&quot; menu commands." ID="ID_1695842943"/>
-<node TEXT="This node is just to facilitate the access to these commands." ID="ID_677846402"/>
+<node TEXT="This node has children nodes with links to following menu commands:" ID="ID_1695842943">
+<node TEXT="**Build add-on**" ID="ID_552607406"/>
+<node TEXT="**Package add-on for publication**" ID="ID_1347649648"/>
+<node TEXT="**Export Translations**" ID="ID_347270789"/>
+<node TEXT="**Import Translations**" ID="ID_439625197"/>
+</node>
+<node TEXT="This node is just to facilitate the access to these commands" ID="ID_677846402"/>
 </node>
 </node>
-<node TEXT="new features" ID="ID_992339106">
+<node TEXT="new commands" ID="ID_992339106">
 <node TEXT="list" STYLE_REF="MarkdownHelperNode" ID="ID_1977967499"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
@@ -585,10 +587,7 @@ blockquote {
   </body>
 </html></richcontent>
 <node TEXT="**Export Translation**" ID="ID_167125793">
-<node TEXT="Exports translations as properties files to &apos;translations&apos; folder" ID="ID_1342955431">
-<node TEXT="Only if a &apos;translations&apos; folder exists" ID="ID_673156701"/>
-<node TEXT="You have to create a &apos;translations&apos; folder in your projects folder, if you want to use this feature." ID="ID_358160968"/>
-</node>
+<node TEXT="Exports translations as properties files to &apos;translations&apos; folder" ID="ID_1342955431"/>
 <node TEXT="This way you can work on the localization with other special tools" ID="ID_1552626298">
 <node TEXT="text block" STYLE_REF="MarkdownHelperNode" ID="ID_1998828916"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
@@ -636,6 +635,28 @@ blockquote {
 <node TEXT="This way you can update the add-on with the localization files" ID="ID_1613832037"/>
 <node TEXT="This feature is also automatically applied when packaging the add-on.&#xa;Added by GPAPP" ID="ID_133914881"/>
 </node>
+<node TEXT="**Inspect installed Add-On**" ID="ID_335090914">
+<node TEXT="Inserts a node with the properties information of the installed add-on you select" ID="ID_1303739816"/>
+<node TEXT="A dialog appears where you can select from a list with all the installed add-ons" ID="ID_1546556617"/>
+</node>
+</node>
+</node>
+<node TEXT="other changes" ID="ID_1056104045">
+<node TEXT="list" STYLE_REF="MarkdownHelperNode" ID="ID_473078812"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      = edofro.MarkDownHelper.MDH.list(node)
+    </p>
+  </body>
+</html></richcontent>
+<node TEXT="Now it proposes a menu text for the new scripts based on its file name" ID="ID_1343062747">
+<node TEXT="It transform a camelCase file name into a normal phrase" ID="ID_240366936"/>
+</node>
+<node TEXT="&quot;**Package add-on for publication**&quot; can now open the new add-on for directly installation" ID="ID_250352766"/>
 </node>
 </node>
 </node>
@@ -652,6 +673,14 @@ blockquote {
     </p>
   </body>
 </html></richcontent>
+<node TEXT="v0.9.29" ID="ID_1414945820">
+<node TEXT="Added inspectInstalledAddOn" ID="ID_1828357472"/>
+<node TEXT="Added &quot;Export Translations&quot; and &quot;Import Translations&quot; to &quot;actions&quot; node" ID="ID_1249621287"/>
+<node TEXT="Now it proposes a menu text for the new scripts based on its file name" ID="ID_1682924207"/>
+<node TEXT="It deletes the &apos;actions&apos; node in the add-on package" ID="ID_1692682693"/>
+<node TEXT="&quot;Export Translations&quot; creates &apos;translations&apos; folder if it doesn&apos;t exist" ID="ID_1152663184"/>
+<node TEXT="releaseAddOn now can install the add-on directly" ID="ID_536532065"/>
+</node>
 <node TEXT="v0.9.28" FOLDED="true" ID="ID_1070972671">
 <attribute_layout VALUE_WIDTH="100 pt"/>
 <node TEXT="Merged with GPAPP devtools version" ID="ID_81663064"/>
@@ -771,6 +800,37 @@ blockquote {
 </node>
 </node>
 </node>
+</node>
+</node>
+<node TEXT="temp scripts" POSITION="right" ID="ID_421122053">
+<node TEXT="bold nodes" ID="ID_635130219"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      c.selecteds.each{n -&gt;
+    </p>
+    <p>
+      &nbsp;&nbsp;&nbsp;&nbsp;n.text = &quot;**${n.plainText}**&quot;
+    </p>
+    <p>
+      }
+    </p>
+  </body>
+</html></richcontent>
+<richcontent CONTENT-TYPE="xml/" TYPE="DETAILS">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      .groovy
+    </p>
+  </body>
+</html></richcontent>
 </node>
 </node>
 <node TEXT="**IMPORTANT**:  &#xa;This map needs that the **MarkdownHelper** add-on is installed to work properly." LOCALIZED_STYLE_REF="styles.important" POSITION="left" ID="ID_1035125343" ICON_SIZE="96 pt" BACKGROUND_COLOR="#ffff00" STYLE="rectangle" SHAPE_HORIZONTAL_MARGIN="10 pt" SHAPE_VERTICAL_MARGIN="10 pt" FORMAT="markdownPatternFormat" BORDER_WIDTH="3 px" MAX_WIDTH="13 cm">

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ And its official websites are:
 
 In this fork I united the last version from [HaaiHenkie](https://sourceforge.net/u/haaihenkie/profile/) ([v.0.9.27](https://github.com/HaaiHenkie/addons/tree/fix-bug-2847), look this [thread](https://sourceforge.net/p/freeplane/bugs/2847/)) with the [version](https://github.com/gpapp/freeplane-devtools) from [gpapp](https://sourceforge.net/u/gergelypapp/profile/) .
 
-The instalable file (```devtools-v0.9.28.addon.mm```) of the latest version of the this fork can be downloaded from [here](https://github.com/EdoFro/freeplane-devtools/releases/latest/).
+The instalable file (```devtools-v0.9.29.addon.mm```) of the latest version of the this fork can be downloaded from [here](https://github.com/EdoFro/freeplane-devtools/releases/latest/).
 
 bye,
 
@@ -94,15 +94,17 @@ The functions are available under Tools -> Development Tools
 #### 2.3.2. "actions" node
 
 * When building a new add-on, now it adds a new "**action**" node.
-* This node has two children nodes with links to the "**Build add-on**" and "**Package add-on for publication**" menu commands.
-* This node is just to facilitate the access to these commands.
+* This node has children nodes with links to following menu commands:
+   * **Build add-on**
+   * **Package add-on for publication**
+   * **Export Translations**
+   * **Import Translations**
+* This node is just to facilitate the access to these commands
 
-#### 2.3.3. new features
+#### 2.3.3. new commands
 
 * **Export Translation**
    * Exports translations as properties files to 'translations' folder
-      * Only if a 'translations' folder exists
-      * You have to create a 'translations' folder in your projects folder, if you want to use this feature.
    * This way you can work on the localization with other special tools
       * I'm using [IniTranslator](https://sourceforge.net/projects/initranslator/) to edit these ```*.properties ``` files, but, as far as I know, there are plenty of different tools to do this.
 * **Import Translation**
@@ -110,9 +112,25 @@ The functions are available under Tools -> Development Tools
       * Only if a 'translations' folder exists
    * This way you can update the add-on with the localization files
    * This feature is also automatically applied when packaging the add-on.<br>Added by GPAPP
+* **Inspect installed Add-On**
+   * Inserts a node with the properties information of the installed add-on you select
+   * A dialog appears where you can select from a list with all the installed add-ons
+
+#### 2.3.4. other changes
+
+* Now it proposes a menu text for the new scripts based on its file name
+   * It transform a camelCase file name into a normal phrase
+* "**Package add-on for publication**" can now open the new add-on for directly installation
 
 ## 3. Change Log
 
+* v0.9.29
+   * Added inspectInstalledAddOn
+   * Added "Export Translations" and "Import Translations" to "actions" node
+   * Now it proposes a menu text for the new scripts based on its file name
+   * It deletes the 'actions' node in the add-on package
+   * "Export Translations" creates 'translations' folder if it doesn't exist
+   * releaseAddOn now can install the add-on directly
 * v0.9.28
    * Merged with GPAPP devtools version
    * Added improved downloadUrl

--- a/src/resources/devtools.mm
+++ b/src/resources/devtools.mm
@@ -1,10 +1,11 @@
 <map version="freeplane 1.9.8">
 <!--To view this file, download free mind mapping software Freeplane from https://www.freeplane.org -->
-<node TEXT="devtools" FOLDED="false" ID="ID_1723255651" LINK="https://github.com/EdoFro/freeplane-devtools" BACKGROUND_COLOR="#97c7dc" VGAP_QUANTITY="2 pt">
+<attribute_registry SHOW_ATTRIBUTES="hide"/>
+<node TEXT="devtools" FOLDED="false" ID="ID_1723255651" CREATED="1642769742437" MODIFIED="1642770982837" LINK="https://github.com/EdoFro/freeplane-devtools" BACKGROUND_COLOR="#97c7dc" VGAP_QUANTITY="2 pt">
 <font SIZE="16" BOLD="true" ITALIC="true"/>
 <attribute_layout NAME_WIDTH="112.5 pt" VALUE_WIDTH="179.99999 pt"/>
 <attribute NAME="name" VALUE="devtools"/>
-<attribute NAME="version" VALUE="v0.9.28"/>
+<attribute NAME="version" VALUE="v0.9.29"/>
 <attribute NAME="author" VALUE="Volker Börchers, Henk van den Akker, Gergely Papp, Edo Frohlich"/>
 <attribute NAME="freeplaneVersionFrom" VALUE="v1.8.0"/>
 <attribute NAME="freeplaneVersionTo" VALUE=""/>
@@ -54,7 +55,7 @@
 </html>
 </richcontent>
 <hook NAME="MapStyle" zoom="0.909">
-    <properties mapUsesOwnSaveOptions="true" save_last_visited_node="default" save_modification_times="false" show_icon_for_attributes="true" fit_to_viewport="false" show_note_icons="true" edgeColorConfiguration="#808080ff,#ff0000ff,#0000ffff,#00ff00ff,#ff00ffff,#00ffffff,#7c0000ff,#00007cff,#007c00ff,#7c007cff,#007c7cff,#7c7c00ff" save_folding="default"/>
+    <properties save_modification_times="false" save_last_visited_node="default" mapUsesOwnSaveOptions="true" fit_to_viewport="false" show_icon_for_attributes="true" show_note_icons="true" edgeColorConfiguration="#808080ff,#ff0000ff,#0000ffff,#00ff00ff,#ff00ffff,#00ffffff,#7c0000ff,#00007cff,#007c00ff,#7c007cff,#007c7cff,#7c7c00ff" save_folding="default"/>
 
 <map_styles>
 <stylenode LOCALIZED_TEXT="styles.root_node" ID="ID_826352276" STYLE="oval" UNIFORM_SHAPE="true" VGAP_QUANTITY="24 pt">
@@ -120,7 +121,7 @@
 </stylenode>
 </map_styles>
 </hook>
-<node TEXT="description" POSITION="left" ID="ID_328053546" VGAP_QUANTITY="2 pt"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="description" POSITION="left" ID="ID_328053546" CREATED="1642769742439" MODIFIED="1642770982847" VGAP_QUANTITY="2 pt"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -139,7 +140,7 @@
 </html>
 </richcontent>
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node ID="ID_1187826020" BACKGROUND_COLOR="#ffff75" VSHIFT_QUANTITY="2.25 pt"><richcontent TYPE="NODE">
+<node ID="ID_1187826020" CREATED="1642769742439" MODIFIED="1642770941997" BACKGROUND_COLOR="#ffff75" VSHIFT_QUANTITY="2.25 pt"><richcontent TYPE="NODE">
 
 <html>
   <head>
@@ -160,13 +161,13 @@
         <i><font size="3">Generate add-on documentation</font></i><font size="3">: Creates a snippet for the Freeplane add-ons wiki page. </font>
       </li>
       <li>
-        <i><font size="3">Insert binary</font></i><font size="3">: Asks for a file to insert as text of the current node&#160;(BASE64 encoded). </font>
+        <i><font size="3">Insert binary</font></i><font size="3">: Asks for a file to insert as text of the current node&nbsp;(BASE64 encoded). </font>
       </li>
       <li>
         <i><font size="3">Extract binary</font></i><font size="3">: Asks for a file to extract the BASE64 encoded binary in the current node to. </font>
       </li>
       <li>
-        <i><font size="3">Encode translation</font></i><font size="3">: Encode non-ASCII characters so that they don't get scrambled while packaging or installation. This function is included in <i>Package add-on for release</i>&#160;so you don't need this function. </font>
+        <i><font size="3">Encode translation</font></i><font size="3">: Encode non-ASCII characters so that they don't get scrambled while packaging or installation. This function is included in <i>Package add-on for release</i>&nbsp;so you don't need this function. </font>
       </li>
       <li>
         <i><font size="3">Menu item info</font></i><font size="3">: Shows technical details about a selected menu item. </font>
@@ -174,12 +175,22 @@
       <li>
         <i><font size="3">freeplane.dsld</font></i><font size="3">: Adds Eclipse editor support for predefined script bindings such as node, c, ui, textUtils, ... </font>
       </li>
+      <li>
+        <i><font size="3">Inspect installed Add-On</font></i><font size="3">: Inserts a node with the properties information of the installed add-on you select.</font>
+      </li>
+      <li>
+        <i><font size="3">Export Translations</font></i><font size="3">:Exports translations as properties files to 'translations' folder<br/>This way you can work on the localization with other special tools </font>
+      </li>
+      <li>
+        <i><font size="3">Import Translations</font></i><font size="3">: Imports translations from properties files Only if a 'translations' folder exists<br/>This way you can update the add-on with the localization files<br/>This feature is also automatically applied when packaging the add-on. (Originally added by GPAPP) </font>
+      </li>
     </ul>
     <p>
       <font size="3">The functions are available under Tools -&gt; Development Tools</font>
     </p>
   </body>
 </html>
+
 </richcontent>
 <font SIZE="16"/>
 <attribute_layout VALUE_WIDTH="100 pt"/>
@@ -198,7 +209,7 @@
 </html></richcontent>
 </node>
 </node>
-<node TEXT="scripts" FOLDED="true" POSITION="right" ID="ID_788417856"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="scripts" POSITION="right" ID="ID_788417856" CREATED="1642769742439" MODIFIED="1642770982880"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -315,7 +326,7 @@
   </body>
 </html>
 </richcontent>
-<node TEXT="checkAddOn.groovy" ID="ID_1651569668"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="checkAddOn.groovy" ID="ID_1651569668" CREATED="1642769742440" MODIFIED="1642769742440"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -331,10 +342,16 @@
       So to create a new add-on do this:
     </p>
     <p>
-      &#160;- File-&gt;New
+      &nbsp;- File-&gt;New
     </p>
     <p>
-      &#160;- Tools-&gt;Scripts-&gt;Dev Tools-&gt;Check Add-on
+      &nbsp;- Tools-&gt;Scripts-&gt;Dev Tools-&gt;Check Add-on
+    </p>
+    <p>
+      
+    </p>
+    <p>
+      Build add-on: adds all standard nodes, attributes and notes to the current map. Can be used with an empty Map to create a basic add-on.
     </p>
   </body>
 </html></richcontent>
@@ -349,7 +366,7 @@
 <attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
 </node>
-<node TEXT="releaseAddOn.groovy" ID="ID_1385129437"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="releaseAddOn.groovy" ID="ID_1385129437" CREATED="1642769742440" MODIFIED="1642769742440"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -383,20 +400,10 @@
 <attribute NAME="execute_scripts_without_asking" VALUE="true"/>
 <attribute NAME="execute_scripts_without_file_restriction" VALUE="true"/>
 <attribute NAME="execute_scripts_without_write_restriction" VALUE="true"/>
-<attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
-<attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
+<attribute NAME="execute_scripts_without_exec_restriction" VALUE="true"/>
+<attribute NAME="execute_scripts_without_network_restriction" VALUE="true"/>
 </node>
-<node TEXT="addOnDoc.groovy" ID="ID_263539694"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
-<html>
-  <head>
-    
-  </head>
-  <body>
-    <p>
-      Asks for a file and sets the current node's text to the BASE64 encoded content of the file.
-    </p>
-  </body>
-</html></richcontent>
+<node TEXT="addOnDoc.groovy" ID="ID_263539694" CREATED="1642769742440" MODIFIED="1642769742440">
 <attribute_layout NAME_WIDTH="200.99999 pt" VALUE_WIDTH="200.99999 pt"/>
 <attribute NAME="menuTitleKey" VALUE="addons.${name}.addOnDoc"/>
 <attribute NAME="menuLocation" VALUE="${addonsMenu}/addons.${name}"/>
@@ -407,15 +414,32 @@
 <attribute NAME="execute_scripts_without_write_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
-</node>
-<node TEXT="menuItemInfo.groovy" ID="ID_1073334594"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
   </head>
   <body>
     <p>
-      Asks for a file and sets the current node's text to the BASE64 encoded content of the file.
+      addOnDoc.groovy
+    </p>
+    <p>
+      
+    </p>
+    <p>
+      Generate add-on documentation: Creates a snippet for the Freeplane add-ons wiki page.
+    </p>
+  </body>
+</html></richcontent>
+</node>
+<node TEXT="menuItemInfo.groovy" ID="ID_1073334594" CREATED="1642769742440" MODIFIED="1642769742440"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      Menu item info: Shows technical details about a selected menu item.
     </p>
   </body>
 </html></richcontent>
@@ -430,7 +454,7 @@
 <attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
 </node>
-<node TEXT="insertBinary.groovy" ID="ID_1004069036"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="insertBinary.groovy" ID="ID_1004069036" CREATED="1642769742440" MODIFIED="1642769742440"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -452,17 +476,7 @@
 <attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
 </node>
-<node TEXT="extractBinary.groovy" ID="ID_1968141643"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
-<html>
-  <head>
-    
-  </head>
-  <body>
-    <p>
-      Asks for a file and sets the current node's text to the BASE64 encoded content of the file.
-    </p>
-  </body>
-</html></richcontent>
+<node TEXT="extractBinary.groovy" ID="ID_1968141643" CREATED="1642769742440" MODIFIED="1642769742440">
 <attribute_layout NAME_WIDTH="200.99999 pt" VALUE_WIDTH="200.99999 pt"/>
 <attribute NAME="menuTitleKey" VALUE="addons.${name}.extractBinary"/>
 <attribute NAME="menuLocation" VALUE="${addonsMenu}/addons.${name}"/>
@@ -473,8 +487,25 @@
 <attribute NAME="execute_scripts_without_write_restriction" VALUE="true"/>
 <attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
+<richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      extractBinary.groovy
+    </p>
+    <p>
+      
+    </p>
+    <p>
+      Extract binary: Asks for a file to extract the BASE64 encoded binary in the current node to.
+    </p>
+  </body>
+</html></richcontent>
 </node>
-<node TEXT="encodeTranslations.groovy" ID="ID_699413298">
+<node TEXT="encodeTranslations.groovy" ID="ID_699413298" CREATED="1642769742441" MODIFIED="1642769742441">
 <attribute_layout NAME_WIDTH="209.24999 pt" VALUE_WIDTH="192.74999 pt"/>
 <attribute NAME="menuTitleKey" VALUE="addons.${name}.encodeTranslations"/>
 <attribute NAME="menuLocation" VALUE="${addonsMenu}/addons.${name}"/>
@@ -485,8 +516,25 @@
 <attribute NAME="execute_scripts_without_write_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
+<richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      encodeTranslations.groovy
+    </p>
+    <p>
+      
+    </p>
+    <p>
+      Encode translation: Encode non-ASCII characters so that they don't get scrambled while packaging or installation. This function is included in Package add-on for release so you don't need this function.
+    </p>
+  </body>
+</html></richcontent>
 </node>
-<node TEXT="exportTranslations.groovy" ID="ID_198520850">
+<node TEXT="exportTranslations.groovy" ID="ID_198520850" CREATED="1642769742441" MODIFIED="1642770449586">
 <attribute_layout NAME_WIDTH="202.49999 pt" VALUE_WIDTH="202.49999 pt"/>
 <attribute NAME="menuTitleKey" VALUE="addons.${name}.exportTranslations"/>
 <attribute NAME="menuLocation" VALUE="${addonsMenu}/addons.${name}"/>
@@ -497,8 +545,32 @@
 <attribute NAME="execute_scripts_without_write_restriction" VALUE="true"/>
 <attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
+<richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      exportTranslations.groovy
+    </p>
+    <p>
+      
+    </p>
+    <p>
+      Exports translations as properties files to 'translations' folder
+    </p>
+    <p>
+      This way you can work on the localization with other special tools
+    </p>
+    <p>
+      I'm using IniTranslator to edit these *.properties files, but, as far as I know, there are plenty of different tools to do this.
+    </p>
+  </body>
+</html>
+</richcontent>
 </node>
-<node TEXT="importTranslations.groovy" ID="ID_1737295547">
+<node TEXT="importTranslations.groovy" ID="ID_1737295547" CREATED="1642769742441" MODIFIED="1642770495351">
 <attribute_layout NAME_WIDTH="202.49999 pt" VALUE_WIDTH="202.49999 pt"/>
 <attribute NAME="menuTitleKey" VALUE="addons.${name}.importTranslations"/>
 <attribute NAME="menuLocation" VALUE="${addonsMenu}/addons.${name}"/>
@@ -509,9 +581,68 @@
 <attribute NAME="execute_scripts_without_write_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
 <attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
+<richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      importTranslations.groovy
+    </p>
+    <p>
+      
+    </p>
+    <p>
+      Imports translations from properties files
+    </p>
+    <p>
+      Only if a 'translations' folder exists
+    </p>
+    <p>
+      This way you can update the add-on with the localization files
+    </p>
+    <p>
+      This feature is also automatically applied when packaging the add-on.
+    </p>
+    <p>
+      Added by GPAPP
+    </p>
+  </body>
+</html>
+</richcontent>
+</node>
+<node TEXT="inspectInstalledAddOn.groovy" ID="ID_1089662753" CREATED="1642769742441" MODIFIED="1642770513618">
+<attribute NAME="menuTitleKey" VALUE="addons.${name}.inspectInstalledAddOn"/>
+<attribute NAME="menuLocation" VALUE="${addonsMenu}/addons.${name}"/>
+<attribute NAME="executionMode" VALUE="on_single_node"/>
+<attribute NAME="keyboardShortcut" VALUE=""/>
+<attribute NAME="execute_scripts_without_asking" VALUE="true"/>
+<attribute NAME="execute_scripts_without_file_restriction" VALUE="true"/>
+<attribute NAME="execute_scripts_without_write_restriction" VALUE="false"/>
+<attribute NAME="execute_scripts_without_exec_restriction" VALUE="false"/>
+<attribute NAME="execute_scripts_without_network_restriction" VALUE="false"/>
+<richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<html>
+  <head>
+    
+  </head>
+  <body>
+    <p>
+      Inserts a node with the information of the AddOnProperties of any installed add-on
+    </p>
+    <p>
+      
+    </p>
+    <p>
+      A dialog appears where you can select from a list with all the installed add-ons
+    </p>
+  </body>
+</html>
+</richcontent>
 </node>
 </node>
-<node TEXT="changes" POSITION="left" ID="ID_309963735"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="changes" POSITION="left" ID="ID_309963735" CREATED="1642769742441" MODIFIED="1642770982851"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -523,125 +654,133 @@
   </body>
 </html>
 </richcontent>
-<node TEXT="v0.9" FOLDED="true" ID="ID_781192802">
-<node TEXT="Initial version" ID="ID_1996473369"/>
+<node TEXT="v0.9" FOLDED="true" ID="ID_781192802" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="Initial version" ID="ID_1996473369" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.4" FOLDED="true" ID="ID_1191427697">
-<node TEXT="Adjusted to new add-on format" ID="ID_1401343116"/>
-<node TEXT="checkAddon.groovy: add script attributes and deinstallation rules; check case of add-on name" ID="ID_609744697"/>
+<node TEXT="v0.9.4" FOLDED="true" ID="ID_1191427697" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="Adjusted to new add-on format" ID="ID_1401343116" CREATED="1642769742441" MODIFIED="1642769742441"/>
+<node TEXT="checkAddon.groovy: add script attributes and deinstallation rules; check case of add-on name" ID="ID_609744697" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.5" FOLDED="true" ID="ID_1275139979">
-<node TEXT="Make checkAddOn.groovy work for maps that are not saved" ID="ID_1259871081"/>
+<node TEXT="v0.9.5" FOLDED="true" ID="ID_1275139979" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="Make checkAddOn.groovy work for maps that are not saved" ID="ID_1259871081" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.6" FOLDED="true" ID="ID_1469699162">
-<node TEXT="Add missing file/write permission for insertBinary.groovy" ID="ID_1936917850"/>
+<node TEXT="v0.9.6" FOLDED="true" ID="ID_1469699162" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="Add missing file/write permission for insertBinary.groovy" ID="ID_1936917850" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.7" FOLDED="true" ID="ID_459911057">
-<node TEXT="Add support for images.&#xa;Include icon and screenshot." ID="ID_1859362741"/>
+<node TEXT="v0.9.7" FOLDED="true" ID="ID_459911057" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="Add support for images.&#xa;Include icon and screenshot." ID="ID_1859362741" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.9" FOLDED="true" ID="ID_365307397">
-<node TEXT="Better error messages in case of missing scripts and zips to include.&#xa;Only look for scripts below the scripts node." ID="ID_1413959921"/>
+<node TEXT="v0.9.9" FOLDED="true" ID="ID_365307397" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="Better error messages in case of missing scripts and zips to include.&#xa;Only look for scripts below the scripts node." ID="ID_1413959921" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.10" FOLDED="true" ID="ID_448176076">
-<node TEXT="New: addOnDoc.groovy" ID="ID_257904891"/>
-<node TEXT="releaseAddOn.groovy:&#xa;Creates the release map as model-only to cope with the map open hook that asks if the map should be installed.&#xa;The map is actually saved at the end." ID="ID_19963680"/>
-<node TEXT="new Icons from Predrag Cuklin" ID="ID_1737053784"/>
+<node TEXT="v0.9.10" FOLDED="true" ID="ID_448176076" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="New: addOnDoc.groovy" ID="ID_257904891" CREATED="1642769742441" MODIFIED="1642769742441"/>
+<node TEXT="releaseAddOn.groovy:&#xa;Creates the release map as model-only to cope with the map open hook that asks if the map should be installed.&#xa;The map is actually saved at the end." ID="ID_19963680" CREATED="1642769742441" MODIFIED="1642769742441"/>
+<node TEXT="new Icons from Predrag Cuklin" ID="ID_1737053784" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.11" FOLDED="true" ID="ID_373658102">
-<node TEXT="New: menuItemInfo.groovy" ID="ID_602327673"/>
-<node TEXT="fixes for 1.2.12" ID="ID_300339965"/>
+<node TEXT="v0.9.11" FOLDED="true" ID="ID_373658102" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="New: menuItemInfo.groovy" ID="ID_602327673" CREATED="1642769742441" MODIFIED="1642769742441"/>
+<node TEXT="fixes for 1.2.12" ID="ID_300339965" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.12" FOLDED="true" ID="ID_873759803">
-<node TEXT="menuItem.groovy: copy string to clipboard" ID="ID_1806951604"/>
+<node TEXT="v0.9.12" FOLDED="true" ID="ID_873759803" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="menuItem.groovy: copy string to clipboard" ID="ID_1806951604" CREATED="1642769742441" MODIFIED="1642769742441"/>
 </node>
-<node TEXT="v0.9.13" FOLDED="true" ID="ID_350232820">
-<node TEXT="update for new special translation key &apos;addons.${name}.description&apos;" ID="ID_589172556"/>
-<node TEXT="checkAddOn.groovy checks the name of the script too" ID="ID_1103423593"/>
+<node TEXT="v0.9.13" FOLDED="true" ID="ID_350232820" CREATED="1642769742441" MODIFIED="1642769742441">
+<node TEXT="update for new special translation key &apos;addons.${name}.description&apos;" ID="ID_589172556" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="checkAddOn.groovy checks the name of the script too" ID="ID_1103423593" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.14" FOLDED="true" ID="ID_1988499160">
+<node TEXT="v0.9.14" FOLDED="true" ID="ID_1988499160" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="update for multiple scripting languages" ID="ID_1961614140"/>
-<node TEXT="support for updateUrl" ID="ID_563212535"/>
+<node TEXT="update for multiple scripting languages" ID="ID_1961614140" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="support for updateUrl" ID="ID_563212535" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.15" FOLDED="true" ID="ID_1734128243">
-<node TEXT="adjusted to new scripts location in Freeplane 1.3.x_beta" ID="ID_1916559200"/>
-<node TEXT="update check and release scripts for installation of libs" ID="ID_1872235344"/>
-<node TEXT="checkAddOn.groovy does a lot more checks and automation than before" ID="ID_661774465"/>
+<node TEXT="v0.9.15" FOLDED="true" ID="ID_1734128243" CREATED="1642769742442" MODIFIED="1642769742442">
+<node TEXT="adjusted to new scripts location in Freeplane 1.3.x_beta" ID="ID_1916559200" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="update check and release scripts for installation of libs" ID="ID_1872235344" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="checkAddOn.groovy does a lot more checks and automation than before" ID="ID_661774465" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.16" FOLDED="true" ID="ID_1528553682">
-<node TEXT="Fix Package add-on (Mantis #2106):&#xa;- no recursive searches for required nodes&#xa;- avoid out of memory exception on errors" ID="ID_1301970756"/>
+<node TEXT="v0.9.16" FOLDED="true" ID="ID_1528553682" CREATED="1642769742442" MODIFIED="1642769742442">
+<node TEXT="Fix Package add-on (Mantis #2106):&#xa;- no recursive searches for required nodes&#xa;- avoid out of memory exception on errors" ID="ID_1301970756" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.17" FOLDED="true" ID="ID_1339360497">
-<node TEXT="fix translation encoding" ID="ID_541623240"/>
+<node TEXT="v0.9.17" FOLDED="true" ID="ID_1339360497" CREATED="1642769742442" MODIFIED="1642769742442">
+<node TEXT="fix translation encoding" ID="ID_541623240" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.18" FOLDED="true" ID="ID_95478392">
-<node TEXT="Fix bug in checkAddOn.groovy that prevented uninstall node from being updated." ID="ID_1125811540"/>
+<node TEXT="v0.9.18" FOLDED="true" ID="ID_95478392" CREATED="1642769742442" MODIFIED="1642769742442">
+<node TEXT="Fix bug in checkAddOn.groovy that prevented uninstall node from being updated." ID="ID_1125811540" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.19" FOLDED="true" ID="ID_166560259">
+<node TEXT="v0.9.19" FOLDED="true" ID="ID_166560259" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="added Dutch translation - thanks to Haai Henkie!" ID="ID_214157042"/>
-<node TEXT="checkAddOn.groovy: ignore classpath, .project and freeplane.dsld from scripts/" ID="ID_758381956"/>
+<node TEXT="added Dutch translation - thanks to Haai Henkie!" ID="ID_214157042" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="checkAddOn.groovy: ignore classpath, .project and freeplane.dsld from scripts/" ID="ID_758381956" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.20" FOLDED="true" ID="ID_1518536148">
+<node TEXT="v0.9.20" FOLDED="true" ID="ID_1518536148" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="fix path to version.properties" ID="ID_1713135491"/>
-<node TEXT="#2234 dealing with spaces in filenames leads releaseAddOn.groovy to crash" ID="ID_1164336874"/>
+<node TEXT="fix path to version.properties" ID="ID_1713135491" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="#2234 dealing with spaces in filenames leads releaseAddOn.groovy to crash" ID="ID_1164336874" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.21" FOLDED="true" ID="ID_1668855804">
-<node TEXT="menuItemInfo: adjusted to Freeplane 1.4 while keeping compatibility to 1.3" ID="ID_1688435093"/>
-<node TEXT="releaseAddOn: avoid problems with paths containing spaces" ID="ID_122150363"/>
-<node TEXT="checkAddOn: add check for the add-on homepage" ID="ID_1883189557"/>
-<node TEXT="encodeTranslations: fix menu location" ID="ID_320983619"/>
+<node TEXT="v0.9.21" FOLDED="true" ID="ID_1668855804" CREATED="1642769742442" MODIFIED="1642769742442">
+<node TEXT="menuItemInfo: adjusted to Freeplane 1.4 while keeping compatibility to 1.3" ID="ID_1688435093" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="releaseAddOn: avoid problems with paths containing spaces" ID="ID_122150363" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="checkAddOn: add check for the add-on homepage" ID="ID_1883189557" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="encodeTranslations: fix menu location" ID="ID_320983619" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.22" FOLDED="true" ID="ID_1516811150">
-<node TEXT="added extractBinary" ID="ID_1578685543"/>
+<node TEXT="v0.9.22" FOLDED="true" ID="ID_1516811150" CREATED="1642769742442" MODIFIED="1642769742442">
+<node TEXT="added extractBinary" ID="ID_1578685543" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.23" FOLDED="true" ID="ID_1514294620">
+<node TEXT="v0.9.23" FOLDED="true" ID="ID_1514294620" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="Fix for Freeplane 1.7.x" ID="ID_38718626"/>
+<node TEXT="Fix for Freeplane 1.7.x" ID="ID_38718626" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.24" FOLDED="true" ID="ID_1948756218">
+<node TEXT="v0.9.24" FOLDED="true" ID="ID_1948756218" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="Fix for #2386 Special characters in add-on translations wrongly displayed" ID="ID_457885988">
-<attribute_layout VALUE_WIDTH="100 pt"/>
-</node>
-<node TEXT="#2642 Devtools creates wrong menuTitleKey for scripts" ID="ID_1374600909"/>
-</node>
-<node TEXT="v0.9.25" FOLDED="true" ID="ID_1823309527">
-<attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="#2643 Devtools does not display its add-on name in menu" ID="ID_1184303114">
+<node TEXT="Fix for #2386 Special characters in add-on translations wrongly displayed" ID="ID_457885988" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
-<node TEXT="#2464 test for missing English translations for scripts" ID="ID_1596709901">
+<node TEXT="#2642 Devtools creates wrong menuTitleKey for scripts" ID="ID_1374600909" CREATED="1642769742442" MODIFIED="1642769742442"/>
+</node>
+<node TEXT="v0.9.25" FOLDED="true" ID="ID_1823309527" CREATED="1642769742442" MODIFIED="1642769742442">
+<attribute_layout VALUE_WIDTH="100 pt"/>
+<node TEXT="#2643 Devtools does not display its add-on name in menu" ID="ID_1184303114" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
-<node TEXT="Set icon for devtools sub menu" ID="ID_265129237"/>
-</node>
-<node TEXT="v0.9.26" FOLDED="true" ID="ID_497897109">
-<attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="Fix for #2798 : Menu Item Info error" ID="ID_1640195555">
+<node TEXT="#2464 test for missing English translations for scripts" ID="ID_1596709901" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
+<node TEXT="Set icon for devtools sub menu" ID="ID_265129237" CREATED="1642769742442" MODIFIED="1642769742442"/>
 </node>
-<node TEXT="v0.9.27" FOLDED="true" ID="ID_910769393">
+<node TEXT="v0.9.26" FOLDED="true" ID="ID_497897109" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="#2847 Devtools&apos; checkAddOn.groovy not compatible with Gradle plugin&apos;s directory structure" ID="ID_843234771">
+<node TEXT="Fix for #2798 : Menu Item Info error" ID="ID_1640195555" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
 </node>
-<node TEXT="v0.9.28" ID="ID_1070972671">
+<node TEXT="v0.9.27" FOLDED="true" ID="ID_910769393" CREATED="1642769742442" MODIFIED="1642769742442">
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="Merged with GPAPP devtools version" ID="ID_81663064"/>
-<node TEXT="added improved downloadUrl" ID="ID_438023883"/>
-<node TEXT="Improved updateUrl" ID="ID_1892062819"/>
-<node TEXT="Added addonsMenu" ID="ID_1630300171"/>
-<node TEXT="Added &quot;actions&quot; node with links to Build and Package commands" ID="ID_532968437"/>
-<node TEXT="Added script &quot;exportTranslation&quot;" ID="ID_1550892273"/>
-<node TEXT="Added script &quot;importTranslation&quot;" ID="ID_40737250"/>
-<node TEXT="Added spanish translation" ID="ID_1040264212"/>
+<node TEXT="#2847 Devtools&apos; checkAddOn.groovy not compatible with Gradle plugin&apos;s directory structure" ID="ID_843234771" CREATED="1642769742442" MODIFIED="1642769742442">
+<attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
 </node>
-<node TEXT="license" FOLDED="true" POSITION="left" ID="ID_770036552"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="v0.9.28" ID="ID_1070972671" CREATED="1642769742442" MODIFIED="1642769742442">
+<attribute_layout VALUE_WIDTH="100 pt"/>
+<node TEXT="Merged with GPAPP devtools version" ID="ID_81663064" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="added improved downloadUrl" ID="ID_438023883" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="Improved updateUrl" ID="ID_1892062819" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="Added addonsMenu" ID="ID_1630300171" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="Added &quot;actions&quot; node with links to Build and Package commands" ID="ID_532968437" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="Added script &quot;exportTranslation&quot;" ID="ID_1550892273" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="Added script &quot;importTranslation&quot;" ID="ID_40737250" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="Added spanish translation" ID="ID_1040264212" CREATED="1642769742442" MODIFIED="1642769742442"/>
+</node>
+<node TEXT="v0.9.29" ID="ID_1414945820" CREATED="1642769742442" MODIFIED="1642769742442">
+<node TEXT="Added inspectInstalledAddOn" ID="ID_1282985371" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="Added &quot;Export Translations&quot; and &quot;Import Translations&quot; to &quot;actions&quot; node" ID="ID_1249621287" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="Now it proposes a menu text for the new scripts based on its file name" ID="ID_1682924207" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="It deletes the &apos;actions&apos; node in the add-on package" ID="ID_1692682693" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="&quot;Export Translations&quot; creates &apos;translations&apos; folder if it doesn&apos;t exist" ID="ID_1152663184" CREATED="1642769742442" MODIFIED="1642769742442"/>
+<node TEXT="releaseAddOn now can install the add-on directly" ID="ID_536532065" CREATED="1642769848308" MODIFIED="1642769915554"/>
+</node>
+</node>
+<node TEXT="license" FOLDED="true" POSITION="left" ID="ID_770036552" CREATED="1642769742443" MODIFIED="1642770982854"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -660,9 +799,9 @@
 </html>
 </richcontent>
 <attribute_layout VALUE_WIDTH="100 pt"/>
-<node TEXT="This add-on is free software: you can redistribute it and/or modify&#xa;it under the terms of the GNU General Public License as published by&#xa;the Free Software Foundation, either version 2 of the License, or&#xa;(at your option) any later version.&#xa;&#xa;This program is distributed in the hope that it will be useful,&#xa;but WITHOUT ANY WARRANTY; without even the implied warranty of&#xa;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&#xa;GNU General Public License for more details." ID="ID_1912443753"/>
+<node TEXT="This add-on is free software: you can redistribute it and/or modify&#xa;it under the terms of the GNU General Public License as published by&#xa;the Free Software Foundation, either version 2 of the License, or&#xa;(at your option) any later version.&#xa;&#xa;This program is distributed in the hope that it will be useful,&#xa;but WITHOUT ANY WARRANTY; without even the implied warranty of&#xa;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&#xa;GNU General Public License for more details." ID="ID_1912443753" CREATED="1642769742443" MODIFIED="1642769742443"/>
 </node>
-<node TEXT="preferences.xml" POSITION="left" ID="ID_1267015903"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="preferences.xml" POSITION="left" ID="ID_1267015903" CREATED="1642769742443" MODIFIED="1642770982860"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -679,7 +818,7 @@
 </richcontent>
 <attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
-<node TEXT="default.properties" POSITION="left" ID="ID_1363888784">
+<node TEXT="default.properties" POSITION="left" ID="ID_1363888784" CREATED="1642769742443" MODIFIED="1642770982865">
 <attribute_layout NAME_WIDTH="138.75 pt" VALUE_WIDTH="138.75 pt"/>
 <attribute NAME="${name}.icon" VALUE="/images/${name}-icon.png"/>
 <richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
@@ -703,7 +842,7 @@
 </html>
 </richcontent>
 </node>
-<node TEXT="translations" POSITION="left" ID="ID_1289155258"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="translations" POSITION="left" ID="ID_1289155258" CREATED="1642769742443" MODIFIED="1642770982869"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -726,22 +865,24 @@
   </body>
 </html>
 </richcontent>
-<node TEXT="de" ID="ID_843180817">
-<attribute_layout NAME_WIDTH="173.99999 pt" VALUE_WIDTH="175.49999 pt"/>
+<node TEXT="de" ID="ID_795116528" CREATED="1642769742443" MODIFIED="1642769742443">
+<attribute_layout NAME_WIDTH="184.49999 pt" VALUE_WIDTH="184.49999 pt"/>
+<attribute NAME="addons.${name}.insertBinary" VALUE="Binärdatei einfügen"/>
+<attribute NAME="﻿addons.${name}.inspectInstalledAddOn" VALUE="Add-on Eigenschaften erhalten"/>
 <attribute NAME="addons.${name}.encodeTranslations" VALUE="\u00DCbersetzungen kodieren"/>
 <attribute NAME="addons.${name}.releaseAddOn" VALUE="Add-on-Package erzeugen"/>
 <attribute NAME="addons.${name}.extractBinary" VALUE="Knoten in Bin\u00E4rdatei extrahieren"/>
 <attribute NAME="addons.${name}.addOnDoc" VALUE="Add-on-Dokumentation erzeugen"/>
 <attribute NAME="addons.${name}.importTranslations" VALUE="\u00DCbersetzungen importieren"/>
 <attribute NAME="addons.${name}.checkAddOn" VALUE="Komplettiere Add-on"/>
-<attribute NAME="﻿addons.${name}.insertBinary" VALUE="Binärdatei einfügen"/>
 <attribute NAME="addons.${name}.menuItemInfo" VALUE="Men\u00FCeintrag-Details"/>
 <attribute NAME="addons.${name}.exportTranslations" VALUE="\u00DCbersetzungen exportieren"/>
 <attribute NAME="addons.${name}" VALUE="Entwicklungswerkzeuge"/>
 </node>
-<node TEXT="en" ID="ID_491236257">
-<attribute_layout NAME_WIDTH="173.99999 pt" VALUE_WIDTH="173.99999 pt"/>
+<node TEXT="en" ID="ID_877958400" CREATED="1642769742443" MODIFIED="1642769742443">
+<attribute_layout NAME_WIDTH="194.99999 pt" VALUE_WIDTH="194.99999 pt"/>
 <attribute NAME="addons.${name}.insertBinary" VALUE="Insert Binary"/>
+<attribute NAME="addons.${name}.inspectInstalledAddOn" VALUE="Add-on properties info"/>
 <attribute NAME="addons.${name}.encodeTranslations" VALUE="Encode translations"/>
 <attribute NAME="addons.${name}.releaseAddOn" VALUE="Package add-on for publication"/>
 <attribute NAME="addons.${name}.extractBinary" VALUE="Extract Binary"/>
@@ -751,22 +892,22 @@
 <attribute NAME="addons.${name}.menuItemInfo" VALUE="Menu item info"/>
 <attribute NAME="addons.${name}.exportTranslations" VALUE="Export Translations"/>
 <attribute NAME="addons.${name}" VALUE="Developer Tools"/>
-<attribute NAME="addons.${name}.xx" VALUE=""/>
 </node>
-<node TEXT="es" ID="ID_1351644680">
-<attribute_layout NAME_WIDTH="173.99999 pt" VALUE_WIDTH="185.99999 pt"/>
+<node TEXT="es" ID="ID_1444642303" CREATED="1642769742443" MODIFIED="1642769742443">
+<attribute_layout NAME_WIDTH="184.49999 pt" VALUE_WIDTH="185.99999 pt"/>
+<attribute NAME="addons.${name}.insertBinary" VALUE="Insertar binario"/>
+<attribute NAME="﻿addons.${name}.inspectInstalledAddOn" VALUE="Información de propiedades de add-on"/>
 <attribute NAME="addons.${name}.encodeTranslations" VALUE="Codificar traducciones"/>
 <attribute NAME="addons.${name}.releaseAddOn" VALUE="Empaquetar add-on para su publicación"/>
 <attribute NAME="addons.${name}.extractBinary" VALUE="Extraer binario"/>
 <attribute NAME="addons.${name}.addOnDoc" VALUE="Generar documentación de add-on"/>
 <attribute NAME="addons.${name}.importTranslations" VALUE="Importar traducciones"/>
 <attribute NAME="addons.${name}.checkAddOn" VALUE="Construir add-on"/>
-<attribute NAME="﻿addons.${name}.insertBinary" VALUE="Insertar binario"/>
 <attribute NAME="addons.${name}.menuItemInfo" VALUE="Información de ítem de menú"/>
 <attribute NAME="addons.${name}.exportTranslations" VALUE="Exportar traducciones"/>
 <attribute NAME="addons.${name}" VALUE="Herramientas para desarrolladores"/>
 </node>
-<node TEXT="nl" ID="ID_620341914">
+<node TEXT="nl" ID="ID_1298408245" CREATED="1642769742444" MODIFIED="1642769742444">
 <attribute_layout NAME_WIDTH="173.99999 pt" VALUE_WIDTH="173.99999 pt"/>
 <attribute NAME="addons.${name}.encodeTranslations" VALUE="Vertalingen coderen"/>
 <attribute NAME="addons.${name}" VALUE="Ontwikkeltools"/>
@@ -777,7 +918,7 @@
 <attribute NAME="addons.${name}.insertBinary" VALUE="Binary invoegen"/>
 </node>
 </node>
-<node TEXT="deinstall" POSITION="left" ID="ID_26194671"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="deinstall" POSITION="left" ID="ID_26194671" CREATED="1642769742444" MODIFIED="1642770982873"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -804,8 +945,9 @@
 <attribute NAME="delete" VALUE="${installationbase}/resources/images/devtools.png"/>
 <attribute NAME="delete" VALUE="${installationbase}/resources/images/devtools-icon.png"/>
 <attribute NAME="delete" VALUE="${installationbase}/resources/images/devtools-screenshot-1.png"/>
+<attribute NAME="delete" VALUE="${installationbase}/addons/${name}/scripts/inspectInstalledAddOn.groovy"/>
 </node>
-<node TEXT="zips" POSITION="right" ID="ID_482322757"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="zips" POSITION="right" ID="ID_482322757" CREATED="1642769742444" MODIFIED="1642770982932"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -841,9 +983,9 @@
   </body>
 </html>
 </richcontent>
-<node TEXT="scripts" ID="ID_929040161"/>
+<node TEXT="scripts" ID="ID_929040161" CREATED="1642769742444" MODIFIED="1642769742444"/>
 </node>
-<node TEXT="lib" POSITION="right" ID="ID_492204493"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="lib" POSITION="right" ID="ID_492204493" CREATED="1642769742444" MODIFIED="1642770982927"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -881,7 +1023,7 @@
 </richcontent>
 <attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
-<node TEXT="images" POSITION="right" ID="ID_723709077"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="images" POSITION="right" ID="ID_723709077" CREATED="1642769742444" MODIFIED="1642770982946"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -913,15 +1055,15 @@
   </body>
 </html>
 </richcontent>
-<node TEXT="${name}.png" ID="ID_1002402838"/>
-<node TEXT="${name}-icon.png" ID="ID_1000617651">
+<node TEXT="${name}.png" ID="ID_1002402838" CREATED="1642769742444" MODIFIED="1642769742444"/>
+<node TEXT="${name}-icon.png" ID="ID_1000617651" CREATED="1642769742444" MODIFIED="1642769742444">
 <attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
-<node TEXT="${name}-screenshot-1.png" ID="ID_1150955427">
+<node TEXT="${name}-screenshot-1.png" ID="ID_1150955427" CREATED="1642769742444" MODIFIED="1642769742444">
 <attribute_layout VALUE_WIDTH="100 pt"/>
 </node>
 </node>
-<node TEXT="actions" POSITION="right" ID="ID_757744802"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
+<node TEXT="actions" POSITION="right" ID="ID_757744802" CREATED="1642769742444" MODIFIED="1642770982950"><richcontent TYPE="NOTE" CONTENT-TYPE="xml/">
 <html>
   <head>
     
@@ -931,8 +1073,10 @@
   </body>
 </html>
 </richcontent>
-<node TEXT="Build add-on" ID="ID_1113925331" LINK="menuitem:_addons.devtools.checkAddOn_on_single_node"/>
-<node TEXT="Package add-on for publication" ID="ID_980118363" LINK="menuitem:_addons.devtools.releaseAddOn_on_single_node"/>
+<node TEXT="Build add-on" ID="ID_1113925331" CREATED="1642769742444" MODIFIED="1642769742444" LINK="menuitem:_addons.devtools.checkAddOn_on_single_node"/>
+<node TEXT="Package add-on for publication" ID="ID_344644492" CREATED="1642769742444" MODIFIED="1642769742444" LINK="menuitem:_addons.devtools.releaseAddOn_on_single_node"/>
+<node TEXT="Export Translations" ID="ID_1121027378" CREATED="1642769742444" MODIFIED="1642769742444" LINK="menuitem:_addons.devtools.exportTranslations_on_single_node"/>
+<node TEXT="Import Translations" ID="ID_1727643809" CREATED="1642769742444" MODIFIED="1642769742444" LINK="menuitem:_addons.devtools.importTranslations_on_single_node"/>
 </node>
 </node>
 </map>

--- a/src/resources/scripts/checkAddOn.groovy
+++ b/src/resources/scripts/checkAddOn.groovy
@@ -630,7 +630,7 @@ def actionsNode = findOrCreate(root, 'actions', RIGHT)
 actionsNode.note = withBody '''
  Direct links to menu commands
 '''
-def actions = ['addons.devtools.checkAddOn','addons.devtools.releaseAddOn']
+def actions = ['addons.devtools.checkAddOn','addons.devtools.releaseAddOn','addons.devtools.exportTranslations','addons.devtools.importTranslations']
 actions.each{ acc ->
     def labelText = textUtils.getText(acc)
     if (!actionsNode.children.any{it.text == labelText}) {        

--- a/src/resources/scripts/checkAddOn.groovy
+++ b/src/resources/scripts/checkAddOn.groovy
@@ -65,6 +65,12 @@ def createMissingAttributes(Proxy.Node node, List<String> attributes) {
     }
 }
 
+def toPhrase(String texto){
+    def words = texto.split("(?<!^)(?=[A-Z])")
+    words = words.take(1)*.capitalize() + words.drop(1)*.toLowerCase()
+    return words.join(' ')
+}
+
 Proxy.Node findOrCreate(Proxy.Node parent, String name, boolean isLeft) {
     def node = parent.children.find{ it.plainText == name }
     if (node == null) {
@@ -484,7 +490,7 @@ scriptsNode.children.each {
         , ['execute_scripts_without_exec_restriction', 'false']
         , ['execute_scripts_without_network_restriction', 'false']
     ])
-    createMissingAttributes(englishTranslationsNode, [menuTitleKey])
+    createMissingAttributes(englishTranslationsNode, [ [menuTitleKey, toPhrase(scriptBaseName)] ] )
 }
 
 filesToUninstall.addAll(scriptsNode.children.collect { "addons/\${name}/scripts/${it.plainText}" })

--- a/src/resources/scripts/exportTranslations.groovy
+++ b/src/resources/scripts/exportTranslations.groovy
@@ -14,6 +14,9 @@ if (!parentNode) {
 }
 
 def dir = new File(root.map.file.parent, nodeName)
+if (!dir.isDirectory()){
+    dir.mkdir()
+}
 if (dir.isDirectory()) {
     parentNode.children.each{ n ->
         def fileName = "${n.plainText}.properties".toString()

--- a/src/resources/scripts/inspectInstalledAddOn.groovy
+++ b/src/resources/scripts/inspectInstalledAddOn.groovy
@@ -1,0 +1,61 @@
+import org.freeplane.main.addons.AddOnProperties
+import org.freeplane.main.addons.AddOnsController
+import javax.swing.JOptionPane
+
+//region: ---------Main-------------
+
+String[] addOnsNames = AddOnsController.controller.installedAddOns*.name    // names list of all the installed add-ons
+def question         = 'Select the add-on'
+def title            = 'Get add-on properties'
+def addonName        = showInputDialogList(addOnsNames, title, question, 0) // returns selected add-on name
+
+if (!addonName)
+    return 'no add-on selected'
+def addOnProps = AddOnsController.getController().getInstalledAddOn(addonName)  //gets the AddOnProperties of the selected add-on
+
+def nodo     = node.createChild(addonName)
+nodo.details = 'add-on properties'
+
+addOnProps.properties.each{ k, v -> 
+    nodo.createChild(k).note = prettyPrint(v)
+}
+
+//end:
+
+//region: ---------Methods---------------
+
+def prettyPrint(obj, String  indent = ''){
+    def texto = new StringBuilder()
+    if (obj instanceof ArrayList){
+        obj.eachWithIndex{ o, i ->
+            texto << prettyPrint(o, indent + '  ')
+        }
+    }
+    else if (obj instanceof Map){
+        obj.each{ k, v ->
+            texto << indent << k << ':\n'
+            texto << prettyPrint(v, indent + '    ')
+        }
+    }
+    else {
+        return indent + obj.toString() + '\n\n'
+    }
+    return texto.toString()
+}
+
+
+def showInputDialogList(String[] options, String title = 'Input dialog',String question = 'Please select an option',int defaultOption = 0){
+    String result = (String)JOptionPane.showInputDialog(
+       null,
+       question,
+       title,
+       JOptionPane.QUESTION_MESSAGE,
+       null,
+       options,
+       options[defaultOption]
+    )
+    //return (options as ArrayList).indexOf(result)
+    return result
+}
+
+//end:

--- a/src/resources/scripts/releaseAddOn.groovy
+++ b/src/resources/scripts/releaseAddOn.groovy
@@ -325,6 +325,7 @@ try {
     counts.translations = updateTranslations(releaseMapRoot)     // added by gpapp
     createLatestVersionFile(releaseMapRoot)
     releaseMapRoot['updateUrl'] = toUrl(releaseMapRoot, releaseMapRoot['updateUrl'].toString()) ?: releaseMapRoot['updateUrl']
+    releaseMapRoot.children.find{it.plainText == 'actions'}.delete()
 } catch (Exception e) {
     errors << e.message
     e.printStackTrace()

--- a/src/resources/scripts/releaseAddOn.groovy
+++ b/src/resources/scripts/releaseAddOn.groovy
@@ -351,7 +351,9 @@ Open the new add-on map ${releaseMapFile.name}?"""
         final int selection = JOptionPane.showConfirmDialog(ui.frame, question, dialogTitle, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE)
         if (selection == JOptionPane.YES_OPTION) {
             try {
-                c.newMap(releaseMapFile.toURI().toURL())
+ //               c.mapLoader(releaseMapFile.toURI().toURL())
+                ModeController modeController = Controller.getCurrentModeController()
+                modeController.getMapController().openMap(releaseMapFile.toURI().toURL())
             }
             catch (Exception e) {
                 // we'll expect an exception if the user chooses to install instead of opening the map

--- a/src/resources/translations/de.properties
+++ b/src/resources/translations/de.properties
@@ -1,11 +1,12 @@
-#Tue Jan 18 19:54:12 CLST 2022
+#Thu Jan 20 18:42:24 CLST 2022
+addons.${name}.insertBinary=Binärdatei einfügen
+﻿addons.${name}.inspectInstalledAddOn=Add-on Eigenschaften erhalten
 addons.${name}.encodeTranslations=\\u00DCbersetzungen kodieren
 addons.${name}.releaseAddOn=Add-on-Package erzeugen
 addons.${name}.extractBinary=Knoten in Bin\\u00E4rdatei extrahieren
 addons.${name}.addOnDoc=Add-on-Dokumentation erzeugen
 addons.${name}.importTranslations=\\u00DCbersetzungen importieren
 addons.${name}.checkAddOn=Komplettiere Add-on
-﻿addons.${name}.insertBinary=Binärdatei einfügen
 addons.${name}.menuItemInfo=Men\\u00FCeintrag-Details
 addons.${name}.exportTranslations=\\u00DCbersetzungen exportieren
 addons.${name}=Entwicklungswerkzeuge

--- a/src/resources/translations/en.properties
+++ b/src/resources/translations/en.properties
@@ -1,5 +1,7 @@
-#Tue Jan 18 19:54:12 CLST 2022
+#Thu Jan 20 18:42:24 CLST 2022
 addons.${name}.insertBinary=Insert Binary
+addons.${name}.inspectInstalledAddOn=Add-on properties info
+addons.${name}.exportTranslations.tooltip=Export TranslationsTOOLTIP
 addons.${name}.encodeTranslations=Encode translations
 addons.${name}.releaseAddOn=Package add-on for publication
 addons.${name}.extractBinary=Extract Binary

--- a/src/resources/translations/es.properties
+++ b/src/resources/translations/es.properties
@@ -1,11 +1,12 @@
-#Tue Jan 18 19:54:12 CLST 2022
+#Thu Jan 20 18:42:24 CLST 2022
+addons.${name}.insertBinary=Insertar binario
+﻿addons.${name}.inspectInstalledAddOn=Información de propiedades de add-on
 addons.${name}.encodeTranslations=Codificar traducciones
 addons.${name}.releaseAddOn=Empaquetar add-on para su publicación
 addons.${name}.extractBinary=Extraer binario
 addons.${name}.addOnDoc=Generar documentación de add-on
 addons.${name}.importTranslations=Importar traducciones
 addons.${name}.checkAddOn=Construir add-on
-﻿addons.${name}.insertBinary=Insertar binario
 addons.${name}.menuItemInfo=Información de ítem de menú
 addons.${name}.exportTranslations=Exportar traducciones
 addons.${name}=Herramientas para desarrolladores

--- a/src/resources/translations/nl.properties
+++ b/src/resources/translations/nl.properties
@@ -1,4 +1,4 @@
-#Tue Jan 18 19:54:12 CLST 2022
+#Thu Jan 20 18:42:24 CLST 2022
 addons.${name}.encodeTranslations=Vertalingen coderen
 addons.${name}=Ontwikkeltools
 addons.${name}.addOnDoc=Add-on documentatie genereren


### PR DESCRIPTION
### v0.9.29

- 	Added inspectInstalledAddOn
- 	Added "Export Translations" and "Import Translations" to "actions" node
- 	Now it proposes a menu text for the new scripts based on its file name
- 	It deletes the 'actions' node in the add-on package
- 	"Export Translations" creates 'translations' folder if it doesn't exist
- 	releaseAddOn now can install the add-on directly
